### PR TITLE
Add AddHandler directive for index.cgi

### DIFF
--- a/httpdconf.sh
+++ b/httpdconf.sh
@@ -27,6 +27,7 @@ DocumentRoot @DOCROOT@
 # allow all access to the rolls RPMS
 <Directory @DOCROOT@/install/rolls>
         DirectoryIndex /install/rolls/index.cgi
+	AddHandler cgi-script .cgi
         Allow from all
 </Directory>
 


### PR DESCRIPTION
AddHandler directive may be needed if ScriptAlias directive is set (it is in default Apache config on RHEL/CentOS 7.4).